### PR TITLE
Move hard-coded IRC configuration parameters to appsettings.json

### DIFF
--- a/src/SpikeCore/SpikeCore.Irc.IrcDotNet/IrcClient.cs
+++ b/src/SpikeCore/SpikeCore.Irc.IrcDotNet/IrcClient.cs
@@ -1,39 +1,46 @@
 ﻿using System;
 
 using IrcDotNet;
+using SpikeCore.Irc.Configuration;
 
 namespace SpikeCore.Irc.IrcDotNet
 {
     public class IrcClient : IIrcClient
     {
         private StandardIrcClient _ircClient;
+        private BotConfig _botConfig;
+        
         public Action<string> MessageReceived { get; set; }
 
-        public void Connect()
+        public void Connect(BotConfig botConfig)
         {
+            _botConfig = botConfig;
+            
             _ircClient = new StandardIrcClient();
             _ircClient.RawMessageReceived += IrcClient_RawMessageReceived;
 
             _ircClient.Connected += IrcClient_Connected;
             _ircClient.ConnectFailed += IrcClient_ConnectFailed;
 
-            _ircClient.Connect("chat.freenode.net", 6667, false, new IrcUserRegistrationInfo()
+            _ircClient.Connect(_botConfig.Host, _botConfig.Port, false, new IrcUserRegistrationInfo()
             {
-                NickName = "SpikeCore",
-                RealName = "SpikeCore",
-                UserName = "SpikeCore",
+                NickName = _botConfig.Nickname,
+                RealName = _botConfig.Nickname,
+                UserName = _botConfig.Nickname,
             });
         }
 
         private void IrcClient_Connected(object sender, EventArgs e)
         {
             _ircClient.LocalUser.MessageReceived += LocalUser_MessageReceived;
-            _ircClient.Channels.Join("#spikelite");
+            _botConfig.Channels.ForEach(channel => _ircClient.Channels.Join(channel));
         }
 
         private void LocalUser_MessageReceived(object sender, IrcMessageEventArgs e) => MessageReceived?.Invoke($"{e.Source.Name}: {e.Targets}: {e.Text}");
         private void IrcClient_ConnectFailed(object sender, IrcErrorEventArgs e) => MessageReceived?.Invoke($"IrcClient_ConnectFailed: {e.Error.Message}");
         private void IrcClient_RawMessageReceived(object sender, IrcRawMessageEventArgs e) => MessageReceived?.Invoke($"RAW: {e.RawContent}");
+        
+        // TODO: [Kog 9/17/2018] - Need to wire this back through the UI, which is kinda broken right now anyway...
         public void SendMessage(string message) => _ircClient.LocalUser.SendMessage("#spikelite", message);
     }
 }

--- a/src/SpikeCore/SpikeCore.Irc/Configuration/BotConfig.cs
+++ b/src/SpikeCore/SpikeCore.Irc/Configuration/BotConfig.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+
+namespace SpikeCore.Irc.Configuration
+{
+    public class BotConfig
+    {
+        public string Host { get; set; } 
+        public int Port { get; set; }
+        
+        public string Nickname { get; set; }
+        public List<string> Channels { get; set; }
+    }
+}

--- a/src/SpikeCore/SpikeCore.Irc/IIrcClient.cs
+++ b/src/SpikeCore/SpikeCore.Irc/IIrcClient.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using SpikeCore.Irc.Configuration;
 
 namespace SpikeCore.Irc
 {
@@ -6,7 +7,7 @@ namespace SpikeCore.Irc
     {
         Action<string> MessageReceived { get; set; }
 
-        void Connect();
+        void Connect(BotConfig botConfig);
         void SendMessage(string message);
     }
 }

--- a/src/SpikeCore/SpikeCore.Web/Startup.cs
+++ b/src/SpikeCore/SpikeCore.Web/Startup.cs
@@ -65,6 +65,8 @@ namespace SpikeCore.Web
             services.AddTransient<IIrcClient, IrcClient>();
             services.AddTransient<IBot, Bot>();
             services.AddSingleton<IBotManager, BotManager>();
+            
+            services.AddSingleton(Configuration);
         }
 
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)

--- a/src/SpikeCore/SpikeCore.Web/appsettings.json
+++ b/src/SpikeCore/SpikeCore.Web/appsettings.json
@@ -10,5 +10,13 @@
   "AllowedHosts": "*",
   "Web": {
     "Enabled": true
+  },
+  "Bot": {
+    "Host": "chat.freenode.net",
+    "Port": 6667,
+    "Nickname": "SpikeCore",
+    "Channels": [
+      "#spikelite"
+    ]
   }
 }

--- a/src/SpikeCore/SpikeCore/Bot.cs
+++ b/src/SpikeCore/SpikeCore/Bot.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using Microsoft.Extensions.Configuration;
 using SpikeCore.Irc;
+using SpikeCore.Irc.Configuration;
 
 namespace SpikeCore
 {
@@ -7,6 +9,8 @@ namespace SpikeCore
     {
         private readonly IServiceProvider _serviceProvider;
         private readonly object _ircClientLock = new object();
+        private readonly BotConfig _botConfig = new BotConfig();
+        
         private IIrcClient _ircClient;
         private Action<string> _messageReceived;
 
@@ -33,9 +37,10 @@ namespace SpikeCore
             }
         }
 
-        public Bot(IServiceProvider serviceProvider)
+        public Bot(IServiceProvider serviceProvider, IConfiguration configuration)
         {
             _serviceProvider = serviceProvider;
+            configuration.GetSection("Bot").Bind(_botConfig);
         }
 
         public void Connect()
@@ -45,8 +50,9 @@ namespace SpikeCore
                 if (_ircClient == null)
                 {
                     _ircClient = _serviceProvider.GetService(typeof(IIrcClient)) as IIrcClient;
+                    
                     _ircClient.MessageReceived = _messageReceived;
-                    _ircClient.Connect();
+                    _ircClient.Connect(_botConfig);
                 }
             }
         }

--- a/src/SpikeCore/SpikeCore/SpikeCore.csproj
+++ b/src/SpikeCore/SpikeCore/SpikeCore.csproj
@@ -8,4 +8,7 @@
     <ProjectReference Include="..\SpikeCore.Irc\SpikeCore.Irc.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.1.1" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
* Add `IConfiguration` to container as a singleton
* Add `Bot` block to `appsettings.json` with values previously in `IrcClient.cs`
* Introduce a `BotConfig` type to encapsulate our IRC configuration
* Add a dependency on `Microsoft.Extensions.Configuration.Binder` in `SpikeCore` so we can bind BotConfig
* Percolate the bot config down our callstack

There are a couple of sharp edges, but we'll be taking another pass later to refactor our IoC/DI solution that should address most of them.