### PR TITLE
Tighten up our dependency injection/configuration

### DIFF
--- a/src/SpikeCore/SpikeCore.Irc.IrcDotNet/IrcClient.cs
+++ b/src/SpikeCore/SpikeCore.Irc.IrcDotNet/IrcClient.cs
@@ -7,15 +7,18 @@ namespace SpikeCore.Irc.IrcDotNet
 {
     public class IrcClient : IIrcClient
     {
+        private readonly BotConfig _botConfig;
         private StandardIrcClient _ircClient;
-        private BotConfig _botConfig;
         
         public Action<string> MessageReceived { get; set; }
 
-        public void Connect(BotConfig botConfig)
+        public IrcClient(BotConfig botConfig)
         {
             _botConfig = botConfig;
-            
+        }
+        
+        public void Connect()
+        {            
             _ircClient = new StandardIrcClient();
             _ircClient.RawMessageReceived += IrcClient_RawMessageReceived;
 

--- a/src/SpikeCore/SpikeCore.Irc/IIrcClient.cs
+++ b/src/SpikeCore/SpikeCore.Irc/IIrcClient.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using SpikeCore.Irc.Configuration;
 
 namespace SpikeCore.Irc
 {
@@ -7,7 +6,7 @@ namespace SpikeCore.Irc
     {
         Action<string> MessageReceived { get; set; }
 
-        void Connect(BotConfig botConfig);
+        void Connect();
         void SendMessage(string message);
     }
 }

--- a/src/SpikeCore/SpikeCore.Web/Services/BotManager.cs
+++ b/src/SpikeCore/SpikeCore.Web/Services/BotManager.cs
@@ -8,28 +8,19 @@ namespace SpikeCore.Web.Services
 {
     public class BotManager : IBotManager
     {
-        private readonly IServiceProvider _serviceProvider;
+        private readonly IBot _bot;
         private readonly IHubContext<TestHub> _hubContext;
-        private readonly object _botLock = new object();
-        private IBot _bot;
 
-        public BotManager(IServiceProvider serviceProvider, IHubContext<TestHub> hubContext)
+        public BotManager(IBot bot, IHubContext<TestHub> hubContext)
         {
-            _serviceProvider = serviceProvider;
+            _bot = bot;
             _hubContext = hubContext;
         }
 
         public void Connect()
         {
-            lock (_botLock)
-            {
-                if (_bot == null)
-                {
-                    _bot = _serviceProvider.GetService(typeof(IBot)) as IBot;
-                    _bot.MessageReceived = (message) => _hubContext.Clients.All.SendAsync("ReceiveMessage", message).Wait();
-                    _bot.Connect();
-                }
-            }
+            _bot.MessageReceived = (message) => _hubContext.Clients.All.SendAsync("ReceiveMessage", message).Wait();
+            _bot.Connect();
         }
 
         public void SendMessage(string message)

--- a/src/SpikeCore/SpikeCore.Web/Startup.cs
+++ b/src/SpikeCore/SpikeCore.Web/Startup.cs
@@ -38,6 +38,8 @@ namespace SpikeCore.Web
 
         public IServiceProvider ConfigureServices(IServiceCollection services)
         {
+            var containerBuilder = new ContainerBuilder();
+            
             if (WebConfig.Enabled)
             {
                 services.AddSignalR();
@@ -72,14 +74,25 @@ namespace SpikeCore.Web
             }
 
             var botConfig = new BotConfig(); 
-            Configuration.GetSection("Bot").Bind(botConfig);           
-          
-            services.AddSingleton<IIrcClient, IrcClient>();
-            services.AddSingleton<IBot, Bot>();
-            services.AddSingleton<IBotManager, BotManager>();
-            services.AddSingleton(botConfig);
+            Configuration.GetSection("Bot").Bind(botConfig);
 
-            var containerBuilder = new ContainerBuilder();
+            containerBuilder
+                .RegisterType<IrcClient>()
+                .As<IIrcClient>()
+                .SingleInstance();
+            
+            containerBuilder
+                .RegisterType<Bot>()
+                .As<IBot>()
+                .SingleInstance();
+            
+            containerBuilder
+                .RegisterType<BotManager>()
+                .As<IBotManager>()
+                .SingleInstance();
+            
+            containerBuilder.RegisterInstance(botConfig);
+
             containerBuilder.Populate(services);
 
             containerBuilder

--- a/src/SpikeCore/SpikeCore/Bot.cs
+++ b/src/SpikeCore/SpikeCore/Bot.cs
@@ -1,17 +1,13 @@
 ﻿using System;
-using Microsoft.Extensions.Configuration;
 using SpikeCore.Irc;
-using SpikeCore.Irc.Configuration;
 
 namespace SpikeCore
 {
     public class Bot : IBot
     {
-        private readonly IServiceProvider _serviceProvider;
+        private readonly IIrcClient _ircClient;
         private readonly object _ircClientLock = new object();
-        private readonly BotConfig _botConfig = new BotConfig();
         
-        private IIrcClient _ircClient;
         private Action<string> _messageReceived;
 
         public Action<string> MessageReceived
@@ -37,24 +33,15 @@ namespace SpikeCore
             }
         }
 
-        public Bot(IServiceProvider serviceProvider, IConfiguration configuration)
+        public Bot(IIrcClient ircClient)
         {
-            _serviceProvider = serviceProvider;
-            configuration.GetSection("Bot").Bind(_botConfig);
+            _ircClient = ircClient;
         }
 
         public void Connect()
-        {
-            lock (_ircClientLock)
-            {
-                if (_ircClient == null)
-                {
-                    _ircClient = _serviceProvider.GetService(typeof(IIrcClient)) as IIrcClient;
-                    
-                    _ircClient.MessageReceived = _messageReceived;
-                    _ircClient.Connect(_botConfig);
-                }
-            }
+        {                 
+            _ircClient.MessageReceived = _messageReceived;
+            _ircClient.Connect();
         }
 
         public void SendMessage(string message)


### PR DESCRIPTION
* All `IService` instances are now added as Singletons instead of Transient: we should only have one instance of these
* Stop passing around `IService` to dependencies
    * `BotManager` now takes an `IBot` instead of an `IServiceProvider`
    * `Bot` now takes an `IIrcClient` instead of an `IServiceProvider`
    * Dependencies are now injected instead of pulled from the app context

* We no longer pass around `IConfiguration` to our bot
    * Binding is now done in `Startup`
    * We now register `BotConfig` with the service provider

* Remove a few properties/backing fields we no longer need
* Remove a few of the locks around various `Connect` methods
    * This is where we were pulling from our `IServiceProvider`
    * Our dependencies are now injected via the container
    * A side effect is that it may be possible to call `Connect()` more than once. We're probably going to want to refactor this anyway.