### PR TITLE
Replace rebus with foundatio

### DIFF
--- a/src/SpikeCore/SpikeCore.Messages/SpikeCore.Messages/IrcConnectMessage.cs
+++ b/src/SpikeCore/SpikeCore.Messages/SpikeCore.Messages/IrcConnectMessage.cs
@@ -1,0 +1,7 @@
+namespace SpikeCore.Messages
+{
+    public class IrcConnectMessage
+    {
+        
+    }
+}

--- a/src/SpikeCore/SpikeCore.Messages/SpikeCore.Messages/IrcReceiveMessage.cs
+++ b/src/SpikeCore/SpikeCore.Messages/SpikeCore.Messages/IrcReceiveMessage.cs
@@ -1,0 +1,11 @@
+namespace SpikeCore.Messages
+{
+    public class IrcReceiveMessage
+    {
+        public string Message { get; }
+        public IrcReceiveMessage(string message)
+        {
+            Message = message;
+        }
+    }
+}

--- a/src/SpikeCore/SpikeCore.Messages/SpikeCore.Messages/IrcSendMessage.cs
+++ b/src/SpikeCore/SpikeCore.Messages/SpikeCore.Messages/IrcSendMessage.cs
@@ -1,0 +1,11 @@
+namespace SpikeCore.Messages
+{
+    public class IrcSendMessage
+    {
+        public string Message { get; }
+        public IrcSendMessage(string message)
+        {
+            Message = message;
+        }
+    }
+}

--- a/src/SpikeCore/SpikeCore.Messages/SpikeCore.Messages/SpikeCore.Messages.csproj
+++ b/src/SpikeCore/SpikeCore.Messages/SpikeCore.Messages/SpikeCore.Messages.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netcoreapp2.1</TargetFramework>
+    </PropertyGroup>
+
+</Project>

--- a/src/SpikeCore/SpikeCore.Web/Hubs/TestHub.cs
+++ b/src/SpikeCore/SpikeCore.Web/Hubs/TestHub.cs
@@ -15,14 +15,11 @@ namespace SpikeCore.Web.Hubs
             _botManager = botManager;
         }
 
-        public void Connect()
-        {
-            _botManager.Connect();
-        }
+        public async Task Connect() => await _botManager.ConnectAsync();
 
         public async Task SendMessage(string message)
         {
-            _botManager.SendMessage(message);
+            await _botManager.SendMessageAsync(message);
             await Clients.All.SendAsync("ReceiveMessage", "[Sent from Web UI]: " + message);
         }
     }

--- a/src/SpikeCore/SpikeCore.Web/Services/IBotManager.cs
+++ b/src/SpikeCore/SpikeCore.Web/Services/IBotManager.cs
@@ -1,8 +1,10 @@
-﻿namespace SpikeCore.Web.Services
+﻿using System.Threading.Tasks;
+
+namespace SpikeCore.Web.Services
 {
     public interface IBotManager
     {
-        void Connect();
-        void SendMessage(string message);
+        Task ConnectAsync();
+        Task SendMessageAsync(string message);
     }
 }

--- a/src/SpikeCore/SpikeCore.Web/SpikeCore.Web.csproj
+++ b/src/SpikeCore/SpikeCore.Web/SpikeCore.Web.csproj
@@ -13,8 +13,6 @@
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.1.3" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.4" PrivateAssets="All" />
-    <PackageReference Include="Rebus" Version="4.2.1" />
-    <PackageReference Include="Rebus.Autofac" Version="5.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SpikeCore/SpikeCore.Web/SpikeCore.Web.csproj
+++ b/src/SpikeCore/SpikeCore.Web/SpikeCore.Web.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Autofac" Version="4.8.1" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.3.0" />
+    <PackageReference Include="Foundatio" Version="7.0.1738" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.1.3" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.4" PrivateAssets="All" />

--- a/src/SpikeCore/SpikeCore.Web/Startup.cs
+++ b/src/SpikeCore/SpikeCore.Web/Startup.cs
@@ -10,10 +10,6 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-
-using Rebus.Config;
-using Rebus.Transport.InMem;
-
 using SpikeCore.Data;
 using SpikeCore.Data.Models;
 using SpikeCore.Irc;
@@ -94,12 +90,6 @@ namespace SpikeCore.Web
             containerBuilder.RegisterInstance(botConfig);
 
             containerBuilder.Populate(services);
-
-            containerBuilder
-                .RegisterRebus((configurer, context) =>
-                    configurer
-                        .Transport(t => t.UseInMemoryTransport(new InMemNetwork(), "SpikeBus"))
-                );
 
             return new AutofacServiceProvider(containerBuilder.Build());
         }

--- a/src/SpikeCore/SpikeCore.sln
+++ b/src/SpikeCore/SpikeCore.sln
@@ -13,6 +13,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SpikeCore.Data", "SpikeCore
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SpikeCore", "SpikeCore\SpikeCore.csproj", "{FC68C5CA-7182-4724-8916-6636CEB66A59}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SpikeCore.Messages", "SpikeCore.Messages\SpikeCore.Messages\SpikeCore.Messages.csproj", "{008CCA3B-EED1-4948-AE72-448A2473A30A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -39,6 +41,10 @@ Global
 		{FC68C5CA-7182-4724-8916-6636CEB66A59}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FC68C5CA-7182-4724-8916-6636CEB66A59}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FC68C5CA-7182-4724-8916-6636CEB66A59}.Release|Any CPU.Build.0 = Release|Any CPU
+		{008CCA3B-EED1-4948-AE72-448A2473A30A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{008CCA3B-EED1-4948-AE72-448A2473A30A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{008CCA3B-EED1-4948-AE72-448A2473A30A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{008CCA3B-EED1-4948-AE72-448A2473A30A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/SpikeCore/SpikeCore/IBot.cs
+++ b/src/SpikeCore/SpikeCore/IBot.cs
@@ -1,12 +1,7 @@
-﻿using System;
-
-namespace SpikeCore
+﻿namespace SpikeCore
 {
     public interface IBot
     {
-        Action<string> MessageReceived { get; set; }
-
-        void Connect();
-        void SendMessage(string message);
+        // This is an empty marker interface for now.
     }
 }

--- a/src/SpikeCore/SpikeCore/SpikeCore.csproj
+++ b/src/SpikeCore/SpikeCore/SpikeCore.csproj
@@ -6,9 +6,11 @@
 
   <ItemGroup>
     <ProjectReference Include="..\SpikeCore.Irc\SpikeCore.Irc.csproj" />
+    <ProjectReference Include="..\SpikeCore.Messages\SpikeCore.Messages\SpikeCore.Messages.csproj" />
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Foundatio" Version="7.0.1738" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.1.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- Removes Rebus: we're swapping to Foundatio. Rebus has some issues with nested context (i.e. publishing from a consumer), and Foundatio seems more tailored towards what we're doing.
- Provides a Foundatio version of @AndyCJ's `messagebus-first-pass` branch.

We're going to want to fix the subscription, but @AndyCJ will do that in a followup commit.