### PR TITLE
Auto-wiring for message bus subscriptions using AutoFac and Foundatio.

### DIFF
--- a/src/SpikeCore/SpikeCore.Messages/SpikeCore.Messages/IMessageHandler.cs
+++ b/src/SpikeCore/SpikeCore.Messages/SpikeCore.Messages/IMessageHandler.cs
@@ -1,0 +1,10 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+namespace SpikeCore.Messages
+{
+    public interface IMessageHandler<TMessage>
+    {
+        Task HandleMessageAsync(TMessage message, CancellationToken cancellationToken);
+    }
+}

--- a/src/SpikeCore/SpikeCore.Web/AutofacFoundatio/ContainerBuilderExtensions.cs
+++ b/src/SpikeCore/SpikeCore.Web/AutofacFoundatio/ContainerBuilderExtensions.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Autofac;
+using Autofac.Core;
+
+using Foundatio.Messaging;
+
+using SpikeCore.Messages;
+
+namespace SpikeCore.Web.AutofacFoundatio
+{
+    public static class ContainerBuilderExtensions
+    {
+        public static void RegisterFoundatio(this ContainerBuilder self)
+        {
+            var messageBus = new InMemoryMessageBus() as IMessageBus;
+
+            // Register the message bus so it's still availible as a service if needs be.
+            self
+                .RegisterInstance(messageBus)
+                .As<IMessageBus>()
+                .SingleInstance();
+
+
+            var subscribeAsyncMethodInfo = typeof(IMessageSubscriber)
+                .GetMethods()
+                .Where(methodInfo => methodInfo.Name == "SubscribeAsync")
+                .Single();
+
+            self.RegisterBuildCallback(container =>
+            {
+                // Find the registerd types which impliment IMessageHandler<>
+                var messageHandlerRegistrations = container
+                    .ComponentRegistry
+                    .Registrations
+                    .Where(registration => IsMessageHandler(registration))
+                    .ToList();
+
+                foreach (var messageHandlerRegistration in messageHandlerRegistrations)
+                {
+                    // Find all the individual IMessageHandler<> implimentations on the type
+                    var iMessageHandlerTypes = messageHandlerRegistration
+                        .Activator
+                        .LimitType
+                        .GetInterfaces()
+                        .Where(interfaceType => IsMessageHandler(interfaceType))
+                        .ToList();
+
+                    if (iMessageHandlerTypes.Count() > 0)
+                    {
+                        // When the instance has been created
+                        messageHandlerRegistration.Activated += (sender, eventArgs) =>
+                        {
+                            foreach (var iMessageHandlerType in iMessageHandlerTypes)
+                            {
+                                // Get the message type we're currently working with
+                                var messageType = iMessageHandlerType.GetGenericArguments().Single();
+
+                                // Get the handle method for the message type
+                                var handleMessageAsyncMethodInfo = iMessageHandlerType.GetMethod("HandleMessageAsync", new[] { messageType, typeof(CancellationToken) });
+
+                                // Create a delegate which satisfies SubscribeAsync, and calls the handle method
+                                var messageHandlerParameter = Expression.Parameter(iMessageHandlerType);
+                                var messageParameter = Expression.Parameter(messageType);
+                                var cancellationTokenParameter = Expression.Parameter(typeof(CancellationToken));
+                                var callHandleMessageAsync = Expression.Call(messageHandlerParameter, handleMessageAsyncMethodInfo, messageParameter, cancellationTokenParameter);
+                                var subscribeHandlerLambda = Expression.Lambda(callHandleMessageAsync, messageParameter, cancellationTokenParameter);
+
+                                // Create a delegate which creates the handler delegate, with the handler passed in via closures.
+                                var createSubscribeHandlerLambda = Expression.Lambda(subscribeHandlerLambda, messageHandlerParameter);
+                                var createSubscribeHandler = createSubscribeHandlerLambda.Compile();
+
+                                // Get the subscribe handling delegate by calling the create subscribe handling delegate
+                                var messageHandler = eventArgs.Instance;
+                                var subscribeHandler = createSubscribeHandler.DynamicInvoke(messageHandler);
+
+                                // Call SubscribeAsync passing in the subscribeHandler
+                                var task = (Task)subscribeAsyncMethodInfo
+                                    .MakeGenericMethod(messageType)
+                                    // Type.Missing is used to reprisent using the default value of an optional parameter
+                                    .Invoke(messageBus, new object[] { subscribeHandler, Type.Missing });
+
+                                // This might not be needed. It might be fine to have the subscribe carry on asynchronously
+                                task.Wait();
+                            }
+                        };
+                    }
+                }
+            });
+        }
+
+        private static bool IsMessageHandler(IComponentRegistration registration)
+            => IsMessageHandler(registration.Activator.LimitType);
+
+        private static bool IsMessageHandler(Type type)
+            => (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IMessageHandler<>))
+            || type
+                .GetInterfaces()
+                .Any(interfaceType => interfaceType.IsGenericType && interfaceType.GetGenericTypeDefinition() == typeof(IMessageHandler<>));
+    }
+}

--- a/src/SpikeCore/SpikeCore.Web/Services/BotManager.cs
+++ b/src/SpikeCore/SpikeCore.Web/Services/BotManager.cs
@@ -1,22 +1,33 @@
-﻿using System.Threading.Tasks;
+﻿using System.Threading;
+using System.Threading.Tasks;
+
 using Foundatio.Messaging;
+
 using Microsoft.AspNetCore.SignalR;
+
 using SpikeCore.Messages;
 using SpikeCore.Web.Hubs;
 
 namespace SpikeCore.Web.Services
 {
-    public class BotManager : IBotManager
+    public class BotManager : IBotManager, IMessageHandler<IrcReceiveMessage>
     {
+        private readonly IHubContext<TestHub> _hubContext;
         private readonly IMessageBus _messageBus;
 
         public BotManager(IHubContext<TestHub> hubContext, IMessageBus messageBus)
         {
+            _hubContext = hubContext;
             _messageBus = messageBus;
-            _messageBus.SubscribeAsync<IrcReceiveMessage>(message => hubContext.Clients.All.SendAsync("ReceiveMessage", message.Message));
         }
 
-        public async Task ConnectAsync() => await _messageBus.PublishAsync(new IrcConnectMessage());
-        public async Task SendMessageAsync(string message) => await _messageBus.PublishAsync(new IrcSendMessage(message));
+        public async Task ConnectAsync()
+            => await _messageBus.PublishAsync(new IrcConnectMessage());
+
+        public async Task HandleMessageAsync(IrcReceiveMessage message, CancellationToken cancellationToken)
+            => await _hubContext.Clients.All.SendAsync("ReceiveMessage", message.Message);
+
+        public async Task SendMessageAsync(string message)
+            => await _messageBus.PublishAsync(new IrcSendMessage(message));
     }
 }

--- a/src/SpikeCore/SpikeCore/Bot.cs
+++ b/src/SpikeCore/SpikeCore/Bot.cs
@@ -1,20 +1,39 @@
-﻿using Foundatio.Messaging;
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+using Foundatio.Messaging;
+
 using SpikeCore.Irc;
 using SpikeCore.Messages;
 
 namespace SpikeCore
 {
-    public class Bot : IBot
+    public class Bot : IBot, IMessageHandler<IrcConnectMessage>, IMessageHandler<IrcSendMessage>
     {
+        private readonly IIrcClient _ircClient;
+        private readonly IMessageBus _messageBus;
+
         public Bot(IIrcClient ircClient, IMessageBus messageBus)
         {
-            messageBus.SubscribeAsync<IrcSendMessage>(message => ircClient.SendMessage(message.Message));
+            _ircClient = ircClient;
+            _messageBus = messageBus;
+        }
 
-            messageBus.SubscribeAsync<IrcConnectMessage>(connectMessage =>
-            {
-                ircClient.MessageReceived = (receivedMessage) =>messageBus.PublishAsync(new IrcReceiveMessage(receivedMessage));
-                ircClient.Connect();
-            });
+        public Task HandleMessageAsync(IrcConnectMessage message, CancellationToken cancellationToken)
+        {
+            _ircClient.MessageReceived = (receivedMessage)
+                => _messageBus.PublishAsync(new IrcReceiveMessage(receivedMessage));
+
+            _ircClient.Connect();
+
+            return Task.CompletedTask;
+        }
+
+        public Task HandleMessageAsync(IrcSendMessage message, CancellationToken cancellationToken)
+        { 
+            _ircClient.SendMessage(message.Message);
+
+            return Task.CompletedTask;
         }
     }
 }


### PR DESCRIPTION
Added ContainerBuilderExtensions which has a RegisterFoundatio method for configuring Foundatio and Autofac for auto-wiring IMessageHandler<> instances.
Added IMessageHandler<>.
Changed Bot and BotManager to wrie up thier message subscribing via IMessageHandler<> rather than IMessageBus.

The ExpressionTree code could be replaced with some "simpler" reflection based code, but it works and it's not that bad, so I've left it in.