### PR TITLE
Add a preliminary module system:

### DIFF
--- a/src/SpikeCore/SpikeCore.Web/appsettings.json
+++ b/src/SpikeCore/SpikeCore.Web/appsettings.json
@@ -18,5 +18,8 @@
     "Channels": [
       "#spikelite"
     ]
+  },
+  "Modules": {
+    "TriggerPrefix": "~"
   }
 }

--- a/src/SpikeCore/SpikeCore/Irc/Configuration/ModuleConfiguration.cs
+++ b/src/SpikeCore/SpikeCore/Irc/Configuration/ModuleConfiguration.cs
@@ -1,0 +1,7 @@
+namespace SpikeCore.Irc.Configuration
+{
+    public class ModuleConfiguration
+    {
+        public string TriggerPrefix { get; set; }
+    }
+}

--- a/src/SpikeCore/SpikeCore/Modules/AboutModule.cs
+++ b/src/SpikeCore/SpikeCore/Modules/AboutModule.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using SpikeCore.MessageBus;
+
+namespace SpikeCore.Modules
+{
+    public class AboutModule : ModuleBase
+    {
+        public override string Name => "About";
+        public override string Description => "Provides information about the bot.";
+        public override string Instructions => "about" ;
+
+        private string[] _taglines => new[] {"now in stereo!", "with Smell-O-Vision!", "filmed in technicolor!"};
+        private readonly Random _random = new Random();
+
+        protected override async Task HandleMessageAsyncInternal(IrcChannelMessageMessage message, CancellationToken cancellationToken)
+        {
+            await SendMessageToChannel("SpikeCore: " + _taglines[_random.Next(0, _taglines.Length)]);
+        }
+    }
+}

--- a/src/SpikeCore/SpikeCore/Modules/HelpModule.cs
+++ b/src/SpikeCore/SpikeCore/Modules/HelpModule.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using SpikeCore.MessageBus;
+
+namespace SpikeCore.Modules
+{
+    public class HelpModule : ModuleBase
+    {
+        public override string Name => "Help";
+        public override string Description => "Provides help for the set of modules currently loaded.";
+        public override string Instructions => "help [command]";
+
+        // Prevent a circular dependency issue by lazily evaluating our modules.
+        private readonly Lazy<IEnumerable<IModule>> _modules;
+
+        public HelpModule(Lazy<IEnumerable<IModule>> modules)
+        {
+            _modules = modules;
+        }
+
+        protected override Task HandleMessageAsyncInternal(IrcChannelMessageMessage message, CancellationToken cancellationToken)
+        {
+            var splitMessage = message.Text.Split(" ");
+            return splitMessage.Length <= 1 ? GetModules() : GetHelpForModule(splitMessage[1]);
+        }
+
+        private Task GetHelpForModule(string moduleName)
+        {
+            var module = _modules.Value.FirstOrDefault(x => x.Name.Equals(moduleName, StringComparison.InvariantCultureIgnoreCase));
+
+            if (null != module)
+            {
+                var response = new List<string>
+                {
+                    "Module name: " + module.Name, 
+                    "Module Description: " + module.Description,
+                    "Module Instructions: " + module.Instructions
+                };
+                
+                return SendMessagesToChannel(response);
+            }
+
+            return SendMessageToChannel("No such module exists, please try another.");
+        }
+
+        private Task GetModules()
+        {
+            return SendMessageToChannel("Modules list: " +
+                                        string.Join(", ", _modules.Value.Select(module => module.Name).ToList()));
+        }
+    }
+}

--- a/src/SpikeCore/SpikeCore/Modules/IModule.cs
+++ b/src/SpikeCore/SpikeCore/Modules/IModule.cs
@@ -1,0 +1,9 @@
+namespace SpikeCore.Modules
+{
+    public interface IModule
+    {
+        string Name { get; }
+        string Description { get; }
+        string Instructions { get; }
+    }
+}

--- a/src/SpikeCore/SpikeCore/Modules/ModuleBase.cs
+++ b/src/SpikeCore/SpikeCore/Modules/ModuleBase.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Foundatio.Messaging;
+using SpikeCore.Irc.Configuration;
+using SpikeCore.MessageBus;
+
+namespace SpikeCore.Modules
+{
+    public abstract class ModuleBase : IMessageHandler<IrcChannelMessageMessage>, IModule
+    {
+        public abstract string Name { get; }
+        public abstract string Description { get; }
+        public abstract string Instructions { get; }
+
+        public IMessageBus MessageBus { private get; set; }
+        public ModuleConfiguration Configuration { get; set; }
+
+        public Task HandleMessageAsync(IrcChannelMessageMessage message, CancellationToken cancellationToken)
+        {
+            // TODO [Kog 10/06/2018] : work in access checks etc.
+            return message.Text.StartsWith(Configuration.TriggerPrefix + Name, StringComparison.InvariantCultureIgnoreCase)
+                ? HandleMessageAsyncInternal(message, cancellationToken)
+                : Task.CompletedTask;
+        }
+
+        protected abstract Task HandleMessageAsyncInternal(IrcChannelMessageMessage message, CancellationToken cancellationToken);
+
+        // TODO [Kog 10/06/2018] : Need to wire this back to the originating channel. We don't have a way to do that right now.
+        protected Task SendMessageToChannel(string message)
+        {
+            return MessageBus.PublishAsync(new IrcSendMessage(message));
+        }
+
+        protected Task SendMessagesToChannel(IEnumerable<string> messages)
+        {
+            return MessageBus.PublishAsync(new IrcSendMessage(messages));
+        }
+    }
+}


### PR DESCRIPTION
* Introduces a new ModuleConfiguration section.
    * This has a prefix trigger for now (defaults to `~` like SpikeLite)
    * The ModuleConfiguration is injected into ModuleBase

* Adds IModule and BaseModule as our preliminary abstractions
    * IModule requires properties for the module name, description, and instructions
    * These are in turn used by ModuleBase to do some quick routing, and by the HelpModule to provide help
    * ModuleBase implements ` IMessageHandler<IrcChannelMessageMessage>` out of the box and does some dispatching based on module name
        * This should help reduce boilerplate
        * We'll also do authorization here when we have it
    * ModuleBase does not expose the injected MessageBus out of the box, but instead provides primitives for sending messages
        * We do not have the ability to set the target yet, but will soon
    * Both configuration and the MessageBus are property injected to prevent excess boilerplate with constructor chaining

* Startup's container configuration will scan the SpikeCore assembly looking for types that end with `Module`
    * These will be registered as `IModule`, and have their properties autowired
    * The resulting `IEnumerable` of `IModule` will be injected into the HelpModule wrapped in a `Lazy<>` to prevent circular dependency issues

* Provides two preliminary modules: about, and help