### PR TITLE
Adds a new `Triggers` property to ModuleBase

### DIFF
--- a/src/SpikeCore/SpikeCore/Modules/FactoidModule.cs
+++ b/src/SpikeCore/SpikeCore/Modules/FactoidModule.cs
@@ -16,7 +16,7 @@ namespace SpikeCore.Modules
         public override string Name => "factoids";
         public override string Description => "Keeps track of factoids.";
         public override string Instructions => "factoid <ban|idiot|warn> <message>";
-        public override List<string> Triggers => new List<string> { "ban", "idiot", "warn" };
+        public override IEnumerable<string> Triggers => new List<string> { "ban", "idiot", "warn" };
 
         private readonly SpikeCoreDbContext _context;
         private const int FactDisplayCount = 5;

--- a/src/SpikeCore/SpikeCore/Modules/FactoidModule.cs
+++ b/src/SpikeCore/SpikeCore/Modules/FactoidModule.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -15,10 +16,11 @@ namespace SpikeCore.Modules
         public override string Name => "factoids";
         public override string Description => "Keeps track of factoids.";
         public override string Instructions => "factoid <ban|idiot|warn> <message>";
+        public override List<string> Triggers => new List<string> { "ban", "idiot", "warn" };
 
         private readonly SpikeCoreDbContext _context;
         private const int FactDisplayCount = 5;
-        private static readonly Regex FactoidRegex = new Regex(@"~factoids\s(\w+)\s(\S+)\s?(.*)?");
+        private static readonly Regex FactoidRegex = new Regex(@"~(idiot|ban|warn)\s(\S+)\s?(.*)?");
 
         public FactoidModule(SpikeCoreDbContext context)
         {

--- a/src/SpikeCore/SpikeCore/Modules/ModuleBase.cs
+++ b/src/SpikeCore/SpikeCore/Modules/ModuleBase.cs
@@ -15,7 +15,7 @@ namespace SpikeCore.Modules
         public abstract string Description { get; }
         public abstract string Instructions { get; }
 
-        public virtual List<string> Triggers => new List<string> {Name};
+        public virtual IEnumerable<string> Triggers => new List<string> {Name};
 
         public IMessageBus MessageBus { private get; set; }
         public ModuleConfiguration Configuration { get; set; }


### PR DESCRIPTION
* ModuleBase will default this to be the `Name` property
    * This means anyone not defining a custom trigger will use the module name (e.g. about, help)
    * Or, for things like Factoids, we can use custom triggers (e.g. idiot, warn, ban)
    * These are a prefix: ModuleBase will do `startsWith(triggerPrefix + trigger)` where the prefix is from your config (default: `~`)
    * This is done in an `Any()` across all potential triggers