### PR TITLE
Add network services authentication:

### DIFF
--- a/src/SpikeCore/SpikeCore.Irc.Irc4NetButSmarter/IrcClient.cs
+++ b/src/SpikeCore/SpikeCore.Irc.Irc4NetButSmarter/IrcClient.cs
@@ -11,14 +11,14 @@ namespace SpikeCore.Irc.Irc4NetButSmarter
         private SIRC4N.IrcClient _ircClient = new SIRC4N.IrcClient();
         private Thread _listenThread;
 
-        public override void Connect(string host, int port, string nickname, IEnumerable<string> channelsToJoin)
+        public override void Connect(string host, int port, string nickname, IEnumerable<string> channelsToJoin, bool authenticate, string password)
         {
             _ircClient = new SIRC4N.IrcClient();
             _ircClient.OnRawMessage += _ircClient_OnRawMessage;
             _ircClient.OnRegistered += _ircClient_OnRegistered;
             _ircClient.OnChannelMessage += _ircClient_OnChannelMessage;
 
-            base.Connect(host, port, nickname, channelsToJoin);
+            base.Connect(host, port, nickname, channelsToJoin, authenticate, password);
 
             _ircClient.Connect(host, port);
             _ircClient.Login(nickname, nickname);
@@ -29,6 +29,11 @@ namespace SpikeCore.Irc.Irc4NetButSmarter
 
         private void _ircClient_OnRegistered(object sender, EventArgs e)
         {
+            if (_authenticate)
+            {
+                _ircClient.SendMessage(SIRC4N.SendType.Message, "nickserv", $"identify {_password}");
+            }           
+            
             foreach (var channelToJoin in _channelsToJoin)
             {
                 _ircClient.RfcJoin(channelToJoin);
@@ -47,7 +52,7 @@ namespace SpikeCore.Irc.Irc4NetButSmarter
                 UserName = e.Data.Nick
             });
 
-        public override void SendChannelMessage(string channelname, string message)
-            => _ircClient.SendMessage(SIRC4N.SendType.Message, channelname, message);
+        public override void SendChannelMessage(string channelName, string message)
+            => _ircClient.SendMessage(SIRC4N.SendType.Message, channelName, message);
     }
 }

--- a/src/SpikeCore/SpikeCore.Irc.IrcDotNet/IrcClient.cs
+++ b/src/SpikeCore/SpikeCore.Irc.IrcDotNet/IrcClient.cs
@@ -9,9 +9,9 @@ namespace SpikeCore.Irc.IrcDotNet
     {
         private StandardIrcClient _ircClient;
 
-        public override void Connect(string host, int port, string nickname, IEnumerable<string> channelsToJoin)
+        public override void Connect(string host, int port, string nickname, IEnumerable<string> channelsToJoin, bool authenticate, string password)
         {
-            base.Connect(host, port, nickname, channelsToJoin);
+            base.Connect(host, port, nickname, channelsToJoin, authenticate, password);
 
             _ircClient = new StandardIrcClient();
             _ircClient.RawMessageReceived += IrcClient_RawMessageReceived;
@@ -60,6 +60,11 @@ namespace SpikeCore.Irc.IrcDotNet
         {
             _ircClient.LocalUser.MessageReceived += LocalUser_MessageReceived;
 
+            if (_authenticate)
+            {
+                _ircClient.LocalUser.SendMessage("nickserv", $"identify {_password}");
+            }
+            
             foreach (var channelToJoin in _channelsToJoin)
             {
                 _ircClient.Channels.Join(channelToJoin);

--- a/src/SpikeCore/SpikeCore.Web/appsettings.json
+++ b/src/SpikeCore/SpikeCore.Web/appsettings.json
@@ -17,7 +17,9 @@
     "Nickname": "SpikeCore",
     "Channels": [
       "#spikelite"
-    ]
+    ],
+    "Authenticate": false,
+    "Password": "<fill this in>"
   },
   "Modules": {
     "TriggerPrefix": "~"

--- a/src/SpikeCore/SpikeCore/Irc/Configuration/IrcConnectionConfig.cs
+++ b/src/SpikeCore/SpikeCore/Irc/Configuration/IrcConnectionConfig.cs
@@ -9,5 +9,8 @@ namespace SpikeCore.Irc.Configuration
         
         public string Nickname { get; set; }
         public List<string> Channels { get; set; }
+        
+        public bool Authenticate { get; set; }
+        public string Password { get; set; }
     }
 }

--- a/src/SpikeCore/SpikeCore/Irc/IIrcClient.cs
+++ b/src/SpikeCore/SpikeCore/Irc/IIrcClient.cs
@@ -8,7 +8,7 @@ namespace SpikeCore.Irc
         Action<ChannelMessage> ChannelMessageReceived { get; set; }
         Action<string> MessageReceived { get; set; }
 
-        void Connect(string host, int port, string nickname, IEnumerable<string> channelsToJoin);
-        void SendChannelMessage(string channelname, string message);
+        void Connect(string host, int port, string nickname, IEnumerable<string> channelsToJoin, bool authenticate, string password);
+        void SendChannelMessage(string channelName, string message);
     }
 }

--- a/src/SpikeCore/SpikeCore/Irc/IrcClientBase.cs
+++ b/src/SpikeCore/SpikeCore/Irc/IrcClientBase.cs
@@ -6,13 +6,19 @@ namespace SpikeCore.Irc
     public abstract class IrcClientBase: IIrcClient
     {
         protected IEnumerable<string> _channelsToJoin;
+        protected bool _authenticate;
+        protected string _password;
 
         public virtual Action<string> MessageReceived { get; set; }
         public virtual Action<ChannelMessage> ChannelMessageReceived { get; set; }
 
-        public virtual void Connect(string host, int port, string nickname, IEnumerable<string> channelsToJoin)
-            => _channelsToJoin = channelsToJoin;
+        public virtual void Connect(string host, int port, string nickname, IEnumerable<string> channelsToJoin, bool authenticate, string password)
+        {            
+            _channelsToJoin = channelsToJoin;
+            _authenticate = authenticate;
+            _password = password;
+        }
 
-        public abstract void SendChannelMessage(string channelname, string message);
+        public abstract void SendChannelMessage(string channelName, string message);
     }
 }

--- a/src/SpikeCore/SpikeCore/Irc/IrcConnection.cs
+++ b/src/SpikeCore/SpikeCore/Irc/IrcConnection.cs
@@ -65,7 +65,7 @@ namespace SpikeCore.Irc
 
             _ircClient.MessageReceived = (receivedMessage) => _messageBus.PublishAsync(new IrcReceiveMessage(receivedMessage));
 
-            _ircClient.Connect(_config.Host, _config.Port, _config.Nickname, _config.Channels);
+            _ircClient.Connect(_config.Host, _config.Port, _config.Nickname, _config.Channels, _config.Authenticate, _config.Password);
         }
     }
 }


### PR DESCRIPTION
* Port NickServ identification from SpikeLite
* Adds two new `IrcConnection` settings:
    * `Authenticate` - set to `true` if you want to authenticate with network services
    * `Password` - the password to use when authenticating with network services, if `Authenticate` is set to `true`

We probably also want to port over something that'll wait for confirmation from services before joining channels from SpikeLite. But bed for now...