### PR TITLE
Port "join after identification behavior" from SpikeLite:

### DIFF
--- a/src/SpikeCore/SpikeCore/Irc/IrcClientBase.cs
+++ b/src/SpikeCore/SpikeCore/Irc/IrcClientBase.cs
@@ -5,7 +5,7 @@ namespace SpikeCore.Irc
 {
     public abstract class IrcClientBase: IIrcClient
     {
-        protected IEnumerable<string> _channelsToJoin;
+        private IEnumerable<string> _channelsToJoin;
         protected bool _authenticate;
         protected string _password;
 
@@ -19,6 +19,26 @@ namespace SpikeCore.Irc
             _password = password;
         }
 
+        protected static bool NoticeIsExpectedServicesAgentMessage(string nickname, string notice)
+        {
+            if ("nickserv".Equals(nickname, StringComparison.OrdinalIgnoreCase))
+            {
+                return notice.StartsWith("You are now identified for", StringComparison.OrdinalIgnoreCase) ||
+                       (notice.StartsWith("The nickname", StringComparison.OrdinalIgnoreCase) && notice.EndsWith("is not registered", StringComparison.OrdinalIgnoreCase));
+            }
+
+            return false;
+        }
+        
+        protected void JoinChannelsForNetwork()
+        {            
+            foreach (var channel in _channelsToJoin)
+            {
+                JoinChannel(channel);
+            }
+        }
+        
         public abstract void SendChannelMessage(string channelName, string message);
+        public abstract void JoinChannel(string channelName);
     }
 }


### PR DESCRIPTION
* If authenticate is set to `true` in your config, the bot will now block on NickServ telling you that you've identified before joining channels
    * If it's set to `false`, the bot will join channels as soon as it's connected to a network

* `JoinChannel` is now a first-class method on `IrcClient`, which we'll probably want for admin commands (join/part/quit etc)
* The enumeration of channels to join in `IrcClient` is now private, since implementing classes only need to implement `JoinChannel`
* Both `IrcClient` implementations will now act on `NOTICE` as well as `PRIVMSG` - though we're not piping the former to the web UI yet