### PR TITLE
Add PM support to the bot:

### DIFF
--- a/src/SpikeCore/SpikeCore.Irc.Irc4NetButSmarter/IrcClient.cs
+++ b/src/SpikeCore/SpikeCore.Irc.Irc4NetButSmarter/IrcClient.cs
@@ -16,7 +16,8 @@ namespace SpikeCore.Irc.Irc4NetButSmarter
             _ircClient = new SIRC4N.IrcClient();
             _ircClient.OnRawMessage += _ircClient_OnRawMessage;
             _ircClient.OnRegistered += _ircClient_OnRegistered;
-            _ircClient.OnChannelMessage += _ircClient_OnChannelMessage;
+            _ircClient.OnChannelMessage += _ircClient_OnPrivmsg;
+            _ircClient.OnQueryMessage += _ircClient_OnPrivmsg;
             _ircClient.OnQueryNotice += _ircClient_OnQueryNotice;
 
             base.Connect(host, port, nickname, channelsToJoin, authenticate, password);
@@ -45,8 +46,8 @@ namespace SpikeCore.Irc.Irc4NetButSmarter
         private void _ircClient_OnRawMessage(object sender, SIRC4N.IrcEventArgs e)
             => MessageReceived?.Invoke($"RAW: {e.Data.RawMessage}");
 
-        private void _ircClient_OnChannelMessage(object sender, SIRC4N.IrcEventArgs e)
-            => ChannelMessageReceived?.Invoke(new ChannelMessage()
+        private void _ircClient_OnPrivmsg(object sender, SIRC4N.IrcEventArgs e)
+            => PrivMessageReceived?.Invoke(new PrivMessage()
             {
                 ChannelName = e.Data.Channel,
                 Text = e.Data.Message,
@@ -64,7 +65,10 @@ namespace SpikeCore.Irc.Irc4NetButSmarter
         
         public override void SendChannelMessage(string channelName, string message)
             => _ircClient.SendMessage(SIRC4N.SendType.Message, channelName, message);
-        
+
+        public override void SendPrivateMessage(string nick, string message)
+            => _ircClient.SendMessage(SIRC4N.SendType.Message, nick, message);
+
         public override void JoinChannel(string channelName) 
             => _ircClient.RfcJoin(channelName);        
     }

--- a/src/SpikeCore/SpikeCore.Irc.IrcDotNet/IrcClient.cs
+++ b/src/SpikeCore/SpikeCore.Irc.IrcDotNet/IrcClient.cs
@@ -33,23 +33,24 @@ namespace SpikeCore.Irc.IrcDotNet
             _ircClient.LocalUser.JoinedChannel += LocalUser_JoinedChannel;
             _ircClient.LocalUser.LeftChannel += LocalUser_LeftChannel;
             _ircClient.LocalUser.NoticeReceived += LocalUser_NoticeReceived;
+            _ircClient.LocalUser.MessageReceived += Privmsg_MessageReceived;
         }
 
         private void LocalUser_JoinedChannel(object sender, IrcChannelEventArgs e)
-            => e.Channel.MessageReceived += Channel_MessageReceived;
+            => e.Channel.MessageReceived += Privmsg_MessageReceived;
 
         private void LocalUser_LeftChannel(object sender, IrcChannelEventArgs e)
-            => e.Channel.MessageReceived -= Channel_MessageReceived;
+            => e.Channel.MessageReceived -= Privmsg_MessageReceived;
 
-        private void Channel_MessageReceived(object sender, IrcMessageEventArgs e)
+        private void Privmsg_MessageReceived(object sender, IrcMessageEventArgs e)
         {
-            var ircChannel = (IrcChannel)sender;
+            var ircChannel = sender as IrcChannel;
 
-            if (ircChannel != null && e.Source is IrcUser ircUser)
+            if (e.Source is IrcUser ircUser)
             {
-                ChannelMessageReceived?.Invoke(new ChannelMessage()
+                PrivMessageReceived?.Invoke(new PrivMessage()
                 {
-                    ChannelName = ircChannel.Name,
+                    ChannelName = ircChannel?.Name,
                     UserName = ircUser.NickName,
                     UserHostName = ircUser.HostName,
                     Text = e.Text
@@ -94,7 +95,10 @@ namespace SpikeCore.Irc.IrcDotNet
         
         public override void SendChannelMessage(string channelName, string message)
             => _ircClient.LocalUser.SendMessage(channelName, message);
-        
+
+        public override void SendPrivateMessage(string nick, string message) 
+            => _ircClient.LocalUser.SendMessage(nick, message);
+
         public override void JoinChannel(string channelName) 
             => _ircClient.Channels.Join(channelName);    
     }

--- a/src/SpikeCore/SpikeCore/Irc/IIrcClient.cs
+++ b/src/SpikeCore/SpikeCore/Irc/IIrcClient.cs
@@ -5,10 +5,11 @@ namespace SpikeCore.Irc
 {
     public interface IIrcClient
     {
-        Action<ChannelMessage> ChannelMessageReceived { get; set; }
+        Action<PrivMessage> PrivMessageReceived { get; set; }
         Action<string> MessageReceived { get; set; }
 
         void Connect(string host, int port, string nickname, IEnumerable<string> channelsToJoin, bool authenticate, string password);
         void SendChannelMessage(string channelName, string message);
+        void SendPrivateMessage(string nick, string message);
     }
 }

--- a/src/SpikeCore/SpikeCore/Irc/IrcClientBase.cs
+++ b/src/SpikeCore/SpikeCore/Irc/IrcClientBase.cs
@@ -10,7 +10,7 @@ namespace SpikeCore.Irc
         protected string _password;
 
         public virtual Action<string> MessageReceived { get; set; }
-        public virtual Action<ChannelMessage> ChannelMessageReceived { get; set; }
+        public virtual Action<PrivMessage> PrivMessageReceived { get; set; }
 
         public virtual void Connect(string host, int port, string nickname, IEnumerable<string> channelsToJoin, bool authenticate, string password)
         {            
@@ -39,6 +39,7 @@ namespace SpikeCore.Irc
         }
         
         public abstract void SendChannelMessage(string channelName, string message);
+        public abstract void SendPrivateMessage(string nick, string message);
         public abstract void JoinChannel(string channelName);
     }
 }

--- a/src/SpikeCore/SpikeCore/Irc/PrivMessage.cs
+++ b/src/SpikeCore/SpikeCore/Irc/PrivMessage.cs
@@ -1,6 +1,6 @@
 ﻿namespace SpikeCore.Irc
 {
-    public class ChannelMessage
+    public class PrivMessage
     {
         public string ChannelName { get; set; }
         public string UserName { get; set; }

--- a/src/SpikeCore/SpikeCore/MessageBus/IrcPrivMessage.cs
+++ b/src/SpikeCore/SpikeCore/MessageBus/IrcPrivMessage.cs
@@ -2,12 +2,13 @@
 
 namespace SpikeCore.MessageBus
 {
-    public class IrcChannelMessageMessage
+    public class IrcPrivMessage
     {
         public SpikeCoreUser IdentityUser { get; set; }
         public string ChannelName { get; set; }
         public string UserName { get; set; }
         public string UserHostName { get; set; }
         public string Text { get; set; }
+        public bool Private => null == ChannelName;
     }
 }

--- a/src/SpikeCore/SpikeCore/MessageBus/IrcSendPrivateMessage.cs
+++ b/src/SpikeCore/SpikeCore/MessageBus/IrcSendPrivateMessage.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+
+namespace SpikeCore.MessageBus
+{
+    public class IrcSendPrivateMessage
+    {
+        public string Nick { get; }
+        public IEnumerable<string> Messages { get; }
+
+        public IrcSendPrivateMessage(string nick, string message) : this(nick, new[] { message }) { }
+        public IrcSendPrivateMessage(string nick, IEnumerable<string> messages)
+        {
+            Nick = nick;
+            Messages = messages;
+        }
+    }
+}

--- a/src/SpikeCore/SpikeCore/Modules/AboutModule.cs
+++ b/src/SpikeCore/SpikeCore/Modules/AboutModule.cs
@@ -15,9 +15,9 @@ namespace SpikeCore.Modules
         private string[] _taglines => new[] {"now in stereo!", "with Smell-O-Vision!", "filmed in technicolor!"};
         private readonly Random _random = new Random();
 
-        protected override async Task HandleMessageAsyncInternal(IrcChannelMessageMessage message, CancellationToken cancellationToken)
+        protected override async Task HandleMessageAsyncInternal(IrcPrivMessage request, CancellationToken cancellationToken)
         {
-            await SendMessageToChannel(message.ChannelName, "SpikeCore: " + _taglines[_random.Next(0, _taglines.Length)]);
+            await SendResponse(request, "SpikeCore: " + _taglines[_random.Next(0, _taglines.Length)]);
         }
     }
 }

--- a/src/SpikeCore/SpikeCore/Modules/FactoidModule.cs
+++ b/src/SpikeCore/SpikeCore/Modules/FactoidModule.cs
@@ -27,9 +27,9 @@ namespace SpikeCore.Modules
             _context = context;
         }
 
-        protected override async Task HandleMessageAsyncInternal(IrcChannelMessageMessage message, CancellationToken cancellationToken)
+        protected override async Task HandleMessageAsyncInternal(IrcPrivMessage request, CancellationToken cancellationToken)
         {
-            var match = FactoidRegex.Match(message.Text);
+            var match = FactoidRegex.Match(request.Text);
 
             if (match.Success)
             {
@@ -45,12 +45,12 @@ namespace SpikeCore.Modules
                         Description = description,
                         Type = command,
                         CreationDate = DateTime.UtcNow,
-                        CreatedBy = message.UserName,
+                        CreatedBy = request.UserName,
                         Name = name
                     };
 
                     await SaveOrUpdate(factoid, cancellationToken);
-                    await SendMessageToChannel(message.ChannelName, "Factoid saved.");
+                    await SendResponse(request, "Factoid saved.");
                 }
 
                 // Otherwise we're looking up factoids by name/type.
@@ -83,12 +83,11 @@ namespace SpikeCore.Modules
                         var response =
                             $"Found {count} factoid{pluralization} of type {command}{paginationDisplay} for {name}: {factoidDisplay}";
 
-                        await SendMessageToChannel(message.ChannelName, response);
+                        await SendResponse(request, response);
                     }
                     else
                     {
-                        await SendMessageToChannel(message.ChannelName,
-                            $"No factoids for {name} of type {command}");
+                        await SendResponse(request, $"No factoids for {name} of type {command}");
                     }
                 }
             }

--- a/src/SpikeCore/SpikeCore/Modules/HelpModule.cs
+++ b/src/SpikeCore/SpikeCore/Modules/HelpModule.cs
@@ -22,13 +22,13 @@ namespace SpikeCore.Modules
             _modules = modules;
         }
 
-        protected override Task HandleMessageAsyncInternal(IrcChannelMessageMessage message, CancellationToken cancellationToken)
+        protected override Task HandleMessageAsyncInternal(IrcPrivMessage request, CancellationToken cancellationToken)
         {
-            var splitMessage = message.Text.Split(" ");
-            return splitMessage.Length <= 1 ? GetModules(message.ChannelName) : GetHelpForModule(message.ChannelName, splitMessage[1]);
+            var splitMessage = request.Text.Split(" ");
+            return splitMessage.Length <= 1 ? GetModules(request) : GetHelpForModule(request, splitMessage[1]);
         }
 
-        private Task GetHelpForModule(string channelName, string moduleName)
+        private Task GetHelpForModule(IrcPrivMessage request, string moduleName)
         {
             var module = _modules.Value.FirstOrDefault(x => x.Name.Equals(moduleName, StringComparison.InvariantCultureIgnoreCase));
 
@@ -41,15 +41,15 @@ namespace SpikeCore.Modules
                     "Module Instructions: " + module.Instructions
                 };
                 
-                return SendMessagesToChannel(channelName, response);
+                return SendMessagesToNick(request.UserName, response);
             }
 
-            return SendMessageToChannel(channelName, "No such module exists, please try another.");
+            return SendMessageToNick(request.UserName, "No such module exists, please try another.");
         }
 
-        private Task GetModules(string channelName)
+        private Task GetModules(IrcPrivMessage request)
         {
-            return SendMessageToChannel(channelName, "Modules list: " + string.Join(", ", _modules.Value.Select(module => module.Name).ToList()));
+            return SendMessageToNick(request.UserName, "Modules list: " + string.Join(", ", _modules.Value.Select(module => module.Name).ToList()));
         }
     }
 }

--- a/src/SpikeCore/SpikeCore/Modules/KarmaModule.cs
+++ b/src/SpikeCore/SpikeCore/Modules/KarmaModule.cs
@@ -23,9 +23,9 @@ namespace SpikeCore.Modules
             _context = context;
         }
         
-        protected override async Task HandleMessageAsyncInternal(IrcChannelMessageMessage message, CancellationToken cancellationToken)
+        protected override async Task HandleMessageAsyncInternal(IrcPrivMessage request, CancellationToken cancellationToken)
         {
-            var match = KarmaRegex.Match(message.Text);
+            var match = KarmaRegex.Match(request.Text);
 
             if (match.Success)
             {
@@ -36,7 +36,7 @@ namespace SpikeCore.Modules
                                .SingleOrDefault(k => k.Name.Equals(nick, StringComparison.CurrentCultureIgnoreCase)) ?? new KarmaItem { Name = nick, Karma = 0 };
 
                 // Ignore anyone tweaking their own karma.
-                if (string.IsNullOrEmpty(op) ||!nick.Equals(message.UserName, StringComparison.InvariantCultureIgnoreCase))
+                if (string.IsNullOrEmpty(op) ||!nick.Equals(request.UserName, StringComparison.InvariantCultureIgnoreCase))
                 {
                     if (op.Equals("--"))
                     {
@@ -48,7 +48,7 @@ namespace SpikeCore.Modules
                     }
                     
                     await SaveOrUpdate(user, cancellationToken);            
-                    await SendMessageToChannel(message.ChannelName, $"{user.Name} has a karma of {user.Karma}");   
+                    await SendResponse(request, $"{user.Name} has a karma of {user.Karma}");   
                 }                  
             }
         }


### PR DESCRIPTION
* Inbound PRIVMSG collapsed: the same event/message will handle both public and private PRIVMSG
    * It is almost never the case that the bot would care about the source of the message (public vs. private)
    * The behavior to handle the event will be the same - except for emitting a reply
    * This is actually a tad bit closer to the spec

* `ChannelMessage` renamed to `PrivMessage`, `IrcChannelMessageMessage` renamed to `IrcPrivMessage`
    * Added a `Private` boolean property to `IrcPrivMessage` to make it easier to determine if this is 1:1 or 1:n
    * This is a shortcut that checks to see if the message has a channel target

* Added a `SendPrivateMessage` method to `IIrcClient` to handle actual sending of 1:1 PRIVMSG
    * This will send a new `IrcSendPrivateMessage` message
    * `IrcConnection` has an `IMessageHandler` implementation for this type that will delegate to the new `SendPrivateMessage` on `IIrcClient` implementations

* Added a new `SendResponse` convenience method to `ModuleBase`:
    * This takes an `IrcPrivMessage` and a text message
    * Will attempt to figure out if response should be 1:1 PRIVMSG or 1:N (i.e. PM vs. public response)

* All modules but `HelpModule` now use `SendResponse`.
    * `HelpModule` uses an explicit `SendMessageToNick`
    * We know this module spams, so always returning a 1:1 PRIVMSG (PM) is probably a good idea