### PR TITLE
Add an "admin" module:

### DIFF
--- a/src/SpikeCore/SpikeCore.Irc.Irc4NetButSmarter/IrcClient.cs
+++ b/src/SpikeCore/SpikeCore.Irc.Irc4NetButSmarter/IrcClient.cs
@@ -70,6 +70,16 @@ namespace SpikeCore.Irc.Irc4NetButSmarter
             => _ircClient.SendMessage(SIRC4N.SendType.Message, nick, message);
 
         public override void JoinChannel(string channelName) 
-            => _ircClient.RfcJoin(channelName);        
+            => _ircClient.RfcJoin(channelName);
+
+        public override void PartChannel(string channelName, string reason)
+            => _ircClient.RfcPart(channelName, reason);
+        
+
+        public override void Quit(string quitMessage)
+        {
+            _ircClient.RfcQuit(quitMessage ?? "Quitting...");
+            WebHostCancellationTokenHolder.CancellationTokenSource.Cancel();
+        }
     }
 }

--- a/src/SpikeCore/SpikeCore.Irc.IrcDotNet/IrcClient.cs
+++ b/src/SpikeCore/SpikeCore.Irc.IrcDotNet/IrcClient.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-
 using IrcDotNet;
 
 namespace SpikeCore.Irc.IrcDotNet
@@ -100,6 +99,15 @@ namespace SpikeCore.Irc.IrcDotNet
             => _ircClient.LocalUser.SendMessage(nick, message);
 
         public override void JoinChannel(string channelName) 
-            => _ircClient.Channels.Join(channelName);    
+            => _ircClient.Channels.Join(channelName);
+
+        public override void PartChannel(string channelName, string reason)
+            => _ircClient.Channels.Leave(new[] {channelName}, reason ?? "leaving...");
+
+        public override void Quit(string quitMessage)
+        {
+            _ircClient.Quit(quitMessage ?? "Quitting...");
+            WebHostCancellationTokenHolder.CancellationTokenSource.Cancel();
+        }
     }
 }

--- a/src/SpikeCore/SpikeCore.Web/Program.cs
+++ b/src/SpikeCore/SpikeCore.Web/Program.cs
@@ -4,6 +4,8 @@ using System.Threading.Tasks;
 
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using SpikeCore.Domain;
 
 namespace SpikeCore.Web
 {
@@ -11,12 +13,17 @@ namespace SpikeCore.Web
     {
         public static async Task Main(string[] args)
         {
+            var cancellationTokenSource = new CancellationTokenSource();
+            var tokenHolder = new WebHostCancellationTokenHolder(cancellationTokenSource);
+            
             var webHost = WebHost
                 .CreateDefaultBuilder(args)
+                .ConfigureServices(servicesCollection =>
+                {
+                    servicesCollection.AddSingleton(tokenHolder);
+                })
                 .UseStartup<Startup>()
                 .Build();
-
-            var cancellationTokenSource = new CancellationTokenSource();
 
             Console.CancelKeyPress += (sender, eventArgs) =>
             {

--- a/src/SpikeCore/SpikeCore.Web/Startup.cs
+++ b/src/SpikeCore/SpikeCore.Web/Startup.cs
@@ -98,6 +98,7 @@ namespace SpikeCore.Web
             containerBuilder
                 .RegisterType<IrcClient>()
                 .As<IIrcClient>()
+                .PropertiesAutowired()
                 .SingleInstance();
             
             containerBuilder

--- a/src/SpikeCore/SpikeCore/Domain/WebHostCancellationTokenHolder.cs
+++ b/src/SpikeCore/SpikeCore/Domain/WebHostCancellationTokenHolder.cs
@@ -1,0 +1,14 @@
+using System.Threading;
+
+namespace SpikeCore.Domain
+{
+    public class WebHostCancellationTokenHolder
+    {
+        public CancellationTokenSource CancellationTokenSource { get; private set; }
+        
+        public WebHostCancellationTokenHolder(CancellationTokenSource cancellationTokenSource)
+        {
+            CancellationTokenSource = cancellationTokenSource;
+        } 
+    }
+}

--- a/src/SpikeCore/SpikeCore/Irc/IIrcClient.cs
+++ b/src/SpikeCore/SpikeCore/Irc/IIrcClient.cs
@@ -11,5 +11,8 @@ namespace SpikeCore.Irc
         void Connect(string host, int port, string nickname, IEnumerable<string> channelsToJoin, bool authenticate, string password);
         void SendChannelMessage(string channelName, string message);
         void SendPrivateMessage(string nick, string message);
+        void JoinChannel(string channelName);
+        void PartChannel(string channelName, string reason);
+        void Quit(string quitMessage);
     }
 }

--- a/src/SpikeCore/SpikeCore/Irc/IrcClientBase.cs
+++ b/src/SpikeCore/SpikeCore/Irc/IrcClientBase.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using SpikeCore.Domain;
 
 namespace SpikeCore.Irc
 {
@@ -8,6 +9,7 @@ namespace SpikeCore.Irc
         private IEnumerable<string> _channelsToJoin;
         protected bool _authenticate;
         protected string _password;
+        public WebHostCancellationTokenHolder WebHostCancellationTokenHolder { protected get; set; }
 
         public virtual Action<string> MessageReceived { get; set; }
         public virtual Action<PrivMessage> PrivMessageReceived { get; set; }
@@ -41,5 +43,7 @@ namespace SpikeCore.Irc
         public abstract void SendChannelMessage(string channelName, string message);
         public abstract void SendPrivateMessage(string nick, string message);
         public abstract void JoinChannel(string channelName);
+        public abstract void PartChannel(string channelName, string reason);
+        public abstract void Quit(string quitMessage);
     }
 }

--- a/src/SpikeCore/SpikeCore/Irc/IrcConnection.cs
+++ b/src/SpikeCore/SpikeCore/Irc/IrcConnection.cs
@@ -11,7 +11,8 @@ using SpikeCore.MessageBus;
 
 namespace SpikeCore.Irc
 {
-    public class IrcConnection : IIrcConnection, IMessageHandler<IrcConnectMessage>, IMessageHandler<IrcSendChannelMessage>, IMessageHandler<IrcSendPrivateMessage>
+    public class IrcConnection : IIrcConnection, IMessageHandler<IrcConnectMessage>, IMessageHandler<IrcSendChannelMessage>, 
+        IMessageHandler<IrcSendPrivateMessage>, IMessageHandler<IrcJoinChannelMessage>, IMessageHandler<IrcPartChannelMessage>, IMessageHandler<IrcQuitMessage>
     {
         private readonly IIrcClient _ircClient;
         private readonly IMessageBus _messageBus;
@@ -86,6 +87,24 @@ namespace SpikeCore.Irc
             }
 
             return user;
+        }
+
+        public Task HandleMessageAsync(IrcJoinChannelMessage message, CancellationToken cancellationToken)
+        {
+            _ircClient.JoinChannel(message.Channel);
+            return Task.CompletedTask;
+        }
+
+        public Task HandleMessageAsync(IrcPartChannelMessage message, CancellationToken cancellationToken)
+        {
+            _ircClient.PartChannel(message.Channel, message.Reason);
+            return Task.CompletedTask;
+        }
+
+        public Task HandleMessageAsync(IrcQuitMessage message, CancellationToken cancellationToken)
+        {
+            _ircClient.Quit(message.Reason);
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/SpikeCore/SpikeCore/MessageBus/IrcJoinChannelMessage.cs
+++ b/src/SpikeCore/SpikeCore/MessageBus/IrcJoinChannelMessage.cs
@@ -1,0 +1,12 @@
+namespace SpikeCore.MessageBus
+{
+    public class IrcJoinChannelMessage
+    {
+        public string Channel { get; }
+
+        public IrcJoinChannelMessage(string channel)
+        {
+            Channel = channel;
+        }
+    }
+}

--- a/src/SpikeCore/SpikeCore/MessageBus/IrcPartChannelMessage.cs
+++ b/src/SpikeCore/SpikeCore/MessageBus/IrcPartChannelMessage.cs
@@ -1,0 +1,14 @@
+namespace SpikeCore.MessageBus
+{
+    public class IrcPartChannelMessage
+    {
+        public string Channel { get; }
+        public string Reason { get; }
+
+        public IrcPartChannelMessage(string channel, string reason)
+        {
+            Channel = channel;
+            Reason = reason;
+        }
+    }
+}

--- a/src/SpikeCore/SpikeCore/MessageBus/IrcQuitMessage.cs
+++ b/src/SpikeCore/SpikeCore/MessageBus/IrcQuitMessage.cs
@@ -1,0 +1,12 @@
+namespace SpikeCore.MessageBus
+{
+    public class IrcQuitMessage
+    {
+        public string Reason { get; }
+
+        public IrcQuitMessage(string reason)
+        {
+            Reason = reason;
+        }
+    }
+}

--- a/src/SpikeCore/SpikeCore/Modules/AdminModule.cs
+++ b/src/SpikeCore/SpikeCore/Modules/AdminModule.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using SpikeCore.Data.Models;
+using SpikeCore.MessageBus;
+
+namespace SpikeCore.Modules
+{
+    public class AdminModule : ModuleBase
+    {
+        private static readonly Regex Regex = new Regex(@"~(quit|join|part)\s(.*)?");
+        private static readonly Regex PartRegex = new Regex(@"(\S+)\s(.*)?");
+        
+        public override string Name => "Admin";
+        public override string Description => "Provides administrative features, such as quitting networks.";
+        public override string Instructions => "quit <message>|join <channel>|part <channel> <reason>" ;
+        public override IEnumerable<string> Triggers => new List<string> { "quit", "join", "part"};
+
+        protected override bool AccessAllowed(SpikeCoreUser user)
+        {
+            return base.AccessAllowed(user) && user.Roles.Any(x => x.Equals("Admin", StringComparison.InvariantCultureIgnoreCase));
+        }
+
+        protected override Task HandleMessageAsyncInternal(IrcPrivMessage request, CancellationToken cancellationToken)
+        {
+            var match = Regex.Match(request.Text);
+            if (match.Success)
+            {
+                var command = match.Groups[1].Value;
+                var details = match.Groups[2].Value;
+
+                if (command.Equals("quit", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    IrcClient.Quit(details);
+                }
+                
+                if (command.Equals("join", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    IrcClient.JoinChannel(details);
+                }
+
+                if (command.Equals("part", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    var partMatch = PartRegex.Match(details);
+                    if (partMatch.Success)
+                    {
+                        IrcClient.PartChannel(partMatch.Groups[1].Value, partMatch.Groups[2].Value);
+                    }
+                }
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/SpikeCore/SpikeCore/Modules/AdminModule.cs
+++ b/src/SpikeCore/SpikeCore/Modules/AdminModule.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using Foundatio.Messaging;
 using SpikeCore.Data.Models;
 using SpikeCore.MessageBus;
 
@@ -34,12 +35,12 @@ namespace SpikeCore.Modules
 
                 if (command.Equals("quit", StringComparison.InvariantCultureIgnoreCase))
                 {
-                    IrcClient.Quit(details);
+                    return MessageBus.PublishAsync(new IrcQuitMessage(details));
                 }
                 
                 if (command.Equals("join", StringComparison.InvariantCultureIgnoreCase))
                 {
-                    IrcClient.JoinChannel(details);
+                    return MessageBus.PublishAsync(new IrcJoinChannelMessage(details));
                 }
 
                 if (command.Equals("part", StringComparison.InvariantCultureIgnoreCase))
@@ -47,7 +48,7 @@ namespace SpikeCore.Modules
                     var partMatch = PartRegex.Match(details);
                     if (partMatch.Success)
                     {
-                        IrcClient.PartChannel(partMatch.Groups[1].Value, partMatch.Groups[2].Value);
+                        return MessageBus.PublishAsync(new IrcPartChannelMessage(partMatch.Groups[1].Value,partMatch.Groups[2].Value));
                     }
                 }
             }

--- a/src/SpikeCore/SpikeCore/Modules/FactoidModule.cs
+++ b/src/SpikeCore/SpikeCore/Modules/FactoidModule.cs
@@ -71,13 +71,12 @@ namespace SpikeCore.Modules
                         var pluralization = (count == 1) ? string.Empty : "s";
 
                         var paginationDisplay = (count > FactDisplayCount)
-                            ? string.Format(" (showing the first {0})", Math.Min(count, FactDisplayCount))
+                            ? $" (showing the first {Math.Min(count, FactDisplayCount)})"
                             : string.Empty;
                         
                         var factoidDisplay = matchingFactoids
                             .Take(FactDisplayCount)
-                            .Select(x => string.Format("[{0} at {1} by {2}]", x.Description,
-                                x.CreationDate.ToString("MM/dd/yyyy H:mm:ss UTC"), x.CreatedBy))
+                            .Select(x => $"[{x.Description} at {x.CreationDate:MM/dd/yyyy H:mm:ss UTC} by {x.CreatedBy}]")
                             .Join();
 
                         var response =

--- a/src/SpikeCore/SpikeCore/Modules/ModuleBase.cs
+++ b/src/SpikeCore/SpikeCore/Modules/ModuleBase.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Foundatio.Messaging;
 using SpikeCore.Data.Models;
+using SpikeCore.Irc;
 using SpikeCore.Irc.Configuration;
 using SpikeCore.MessageBus;
 
@@ -21,6 +22,8 @@ namespace SpikeCore.Modules
         public IMessageBus MessageBus { private get; set; }
         public ModuleConfiguration Configuration { private get; set; }
 
+        public IIrcClient IrcClient { protected get; set; }
+        
         // TODO [Kog 10/06/2018] : work in access checks etc.
         public Task HandleMessageAsync(IrcPrivMessage message, CancellationToken cancellationToken)
         {

--- a/src/SpikeCore/SpikeCore/Modules/ModuleBase.cs
+++ b/src/SpikeCore/SpikeCore/Modules/ModuleBase.cs
@@ -5,7 +5,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Foundatio.Messaging;
 using SpikeCore.Data.Models;
-using SpikeCore.Irc;
 using SpikeCore.Irc.Configuration;
 using SpikeCore.MessageBus;
 
@@ -19,12 +18,9 @@ namespace SpikeCore.Modules
 
         public virtual IEnumerable<string> Triggers => new List<string> {Name};
 
-        public IMessageBus MessageBus { private get; set; }
+        public IMessageBus MessageBus { protected get; set; }
         public ModuleConfiguration Configuration { private get; set; }
-
-        public IIrcClient IrcClient { protected get; set; }
         
-        // TODO [Kog 10/06/2018] : work in access checks etc.
         public Task HandleMessageAsync(IrcPrivMessage message, CancellationToken cancellationToken)
         {
             return Triggers.Any(trigger =>


### PR DESCRIPTION
* Supports quit, join, and part right now
* Requires the "Admin" role
* Adds corresponding methods to the `IIrcClient` and `IrcClientBase`
* Our IoC container is now aware of a `WebHostCancellationTokenHolder`
    * This wraps  he `CancellationTokenSource` that our `WebHost` is watching to shut down the app
    * We need this so that our "quit" commands will kill the bot entirely
    * This is injected into the `IrcClientBase` to be used in implementations of `Quit`
    * `Startup` now calls `PropertiesAutowired()` on our `IrcClient` singleton
    * The `WebHost` configured in `Program` registers our `WebHostCancellationTokenHolder` because it's the only thing with enough context