### PR TITLE
Port reconnection from SpikeLite

### DIFF
--- a/src/SpikeCore/SpikeCore.Irc.Irc4NetButSmarter/IrcClient.cs
+++ b/src/SpikeCore/SpikeCore.Irc.Irc4NetButSmarter/IrcClient.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Threading;
 
 using SIRC4N = Meebey.SmartIrc4net;
@@ -10,8 +9,10 @@ namespace SpikeCore.Irc.Irc4NetButSmarter
     {
         private SIRC4N.IrcClient _ircClient = new SIRC4N.IrcClient();
         private Thread _listenThread;
+        
+        public override bool IsConnected => _ircClient.IsConnected;
 
-        public override void Connect(string host, int port, string nickname, IEnumerable<string> channelsToJoin, bool authenticate, string password)
+        protected override void Connect()
         {
             _ircClient = new SIRC4N.IrcClient();
             _ircClient.OnRawMessage += _ircClient_OnRawMessage;
@@ -19,16 +20,26 @@ namespace SpikeCore.Irc.Irc4NetButSmarter
             _ircClient.OnChannelMessage += _ircClient_OnPrivmsg;
             _ircClient.OnQueryMessage += _ircClient_OnPrivmsg;
             _ircClient.OnQueryNotice += _ircClient_OnQueryNotice;
-
-            base.Connect(host, port, nickname, channelsToJoin, authenticate, password);
-
-            _ircClient.Connect(host, port);
-            _ircClient.Login(nickname, nickname);
+            
+            _ircClient.Connect(_host, _port);
+            _ircClient.Login(_nickname, _nickname);
 
             _listenThread = new Thread(_ircClient.Listen);
             _listenThread.Start();
+            
+            _ircClient.OnDisconnected += HandleDisconnect;
         }
 
+        protected override void UnwireEvents()
+        {
+            _ircClient.OnDisconnected -= HandleDisconnect;
+            _ircClient.OnRawMessage += _ircClient_OnRawMessage;
+            _ircClient.OnRegistered += _ircClient_OnRegistered;
+            _ircClient.OnChannelMessage += _ircClient_OnPrivmsg;
+            _ircClient.OnQueryMessage += _ircClient_OnPrivmsg;
+            _ircClient.OnQueryNotice += _ircClient_OnQueryNotice;
+        }
+        
         private void _ircClient_OnRegistered(object sender, EventArgs e)
         {
             if (_authenticate)
@@ -78,6 +89,8 @@ namespace SpikeCore.Irc.Irc4NetButSmarter
 
         public override void Quit(string quitMessage)
         {
+            _userInitiatedDisconnect = true;
+            
             _ircClient.RfcQuit(quitMessage ?? "Quitting...");
             WebHostCancellationTokenHolder.CancellationTokenSource.Cancel();
         }

--- a/src/SpikeCore/SpikeCore.Irc.Irc4NetButSmarter/IrcClient.cs
+++ b/src/SpikeCore/SpikeCore.Irc.Irc4NetButSmarter/IrcClient.cs
@@ -89,7 +89,7 @@ namespace SpikeCore.Irc.Irc4NetButSmarter
 
         public override void Quit(string quitMessage)
         {
-            _userInitiatedDisconnect = true;
+            base.Quit(quitMessage);
             
             _ircClient.RfcQuit(quitMessage ?? "Quitting...");
             WebHostCancellationTokenHolder.CancellationTokenSource.Cancel();

--- a/src/SpikeCore/SpikeCore.Irc.IrcDotNet/IrcClient.cs
+++ b/src/SpikeCore/SpikeCore.Irc.IrcDotNet/IrcClient.cs
@@ -119,7 +119,7 @@ namespace SpikeCore.Irc.IrcDotNet
 
         public override void Quit(string quitMessage)
         {
-            _userInitiatedDisconnect = true;
+            base.Quit(quitMessage);
             
             _ircClient.Quit(quitMessage ?? "Quitting...");
             WebHostCancellationTokenHolder.CancellationTokenSource.Cancel();


### PR DESCRIPTION
* Add a `HandleDisconnect` event handler to `IrcClientBase`
    * This handles a generic retry loop, making use of a few things the inheriting classes need to implement
        * `UnwireEvents` prevents certain IRC clients from colliding things like MOTD handlers on reconnect.
        * It does what it says on the tin: it unwires all events that `Connect` wires up
        * Add an `IsConnected` to prevent infinite retry loops, this is defined by the client with a property body
        * Added a no-arg `Connect`: this does the actual meat of reconnection, and is called by the argful constructor and reconnect handling
    * Calling `quit` now sets a var that short circuits the retry loop

This is more or less equivalent to what we were doing in SpikeLite