### PR TITLE
Swap from using default logging to Serilog:

### DIFF
--- a/src/SpikeCore/SpikeCore.Web/SpikeCore.Web.csproj
+++ b/src/SpikeCore/SpikeCore.Web/SpikeCore.Web.csproj
@@ -14,6 +14,9 @@
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.2.1" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.2.1" PrivateAssets="All" />
+    <PackageReference Include="Serilog.AspNetCore" Version="2.1.1" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="2.6.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SpikeCore/SpikeCore.Web/appsettings.json
+++ b/src/SpikeCore/SpikeCore.Web/appsettings.json
@@ -2,14 +2,28 @@
   "ConnectionStrings": {
     "SpikeCoreDbContextConnection": "DataSource=DB/SpikeCore.db"
   },
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information"
-    }
-  },
   "AllowedHosts": "*",
   "Web": {
     "Enabled": true
+  },
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Debug",
+      "Override": {
+        "Microsoft": "Information"
+      }
+    },
+    "WriteTo": [
+      {
+        "Name": "Console",
+        "Args": {
+          "outputTemplate": "[{Timestamp:u} {Level:u3}] {Message:lj}{NewLine}{Exception}"
+        }
+      }
+    ],
+    "Enrich": [
+      "FromLogContext"
+    ]
   },
   "IrcConnection": {
     "Host": "chat.freenode.net",

--- a/src/SpikeCore/SpikeCore/Irc/IrcClientBase.cs
+++ b/src/SpikeCore/SpikeCore/Irc/IrcClientBase.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading;
+using Serilog;
 using SpikeCore.Domain;
 
 namespace SpikeCore.Irc
@@ -41,19 +42,18 @@ namespace SpikeCore.Irc
             
             while (!_userInitiatedDisconnect && !IsConnected)
             {
-                // TODO - [kog@epiphanic.org 01/20/2019]: Add real logging.
-                Console.WriteLine("Disconnected from IRC server, attempting reconnection...");
+                Log.Warning("Disconnected from IRC server, attempting reconnection...");
                 Connect();
 
                 if (!IsConnected)
                 {
                     // TODO - [kog@epiphanic.org 01/17/2019]: replace with a max retries + exponential backoff
-                    Console.WriteLine("Failed to reconnect. Retrying in 30 seconds...");
+                    Log.Warning("Failed to reconnect. Retrying in 30 seconds...");
                     _reconnectionSemaphore.Wait(TimeSpan.FromSeconds(30));
                 }
             }
             
-            Console.WriteLine("Reconnected successfully.");
+            Log.Information("Reconnected successfully.");
         }
 
         protected static bool NoticeIsExpectedServicesAgentMessage(string nickname, string notice)

--- a/src/SpikeCore/SpikeCore/SpikeCore.csproj
+++ b/src/SpikeCore/SpikeCore/SpikeCore.csproj
@@ -14,5 +14,6 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.2.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="2.2.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.0" />
+    <PackageReference Include="Serilog" Version="2.7.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
* Adds dependencies on Serilog:
    * Serilog at 2.7.1
    * Serilog.AspNetCore at 2.1.1
    * Serilog.Sinks.Console at 3.1.1
    * Serilog.Settings.Configuration at 2.6.1

* Wired up to use `appsettings.json` (with `reloadOnChange` set to true) to configure logging
* The logger has a property-based enrichment for `App Name` set to `Spikecore`
* The default logging will set the minimum level at `Debug`, but a threshold on Microsoft at `Information` because it's spammy
* The default format of log statements is overriden to always use UTC
    * An example log line: `[2019-01-25 14:40:24Z INF] Running, press CTRL-C to stop the bot.`

* Swap out calls to `Console.WriteLine` with appropriate logging